### PR TITLE
feat: add ability to search via the API

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -1,0 +1,4 @@
+# Changes
+
+1. Update the search functionality to use Drizzle's ilike helper for case-insensitive search.
+1. Update the search functionality to search on multiple fields.

--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -1,4 +1,5 @@
 # Changes
 
+1. Update the ability to search for advocates via the API
 1. Update the search functionality to use Drizzle's ilike helper for case-insensitive search.
 1. Update the search functionality to search on multiple fields.

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,12 +1,52 @@
 import db from "../../../db";
 import { advocates } from "../../../db/schema";
 import { advocateData } from "../../../db/seed/advocates";
+import { NextRequest } from "next/server";
+import { sql, or, ilike } from "drizzle-orm";
 
-export async function GET() {
-  // Uncomment this line to use a database
-  const data = await db.select().from(advocates);
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const search = searchParams.get("search") || "";
+    const page = parseInt(searchParams.get("page") || "1", 10);
+    const limit = parseInt(searchParams.get("limit") || "20", 10);
+    const offset = (page - 1) * limit;
 
-  // const data = advocateData;
+    // Build base query
+    let whereClause = undefined;
+    if (search) {
+      whereClause = or(
+        ilike(advocates.firstName, `%${search}%`),
+        ilike(advocates.lastName, `%${search}%`),
+        ilike(advocates.city, `%${search}%`),
+        ilike(advocates.degree, `%${search}%`)
+      );
+    }
 
-  return Response.json({ data });
+    const [{ count }] = await (db
+      .select({ count: sql`count(*)`.as('count') })
+      .from(advocates)
+      .where(whereClause) as any);
+
+    // Main query with pagination and search
+    const results = await (db
+      .select()
+      .from(advocates)
+      .where(whereClause)
+      .limit(limit)
+      .offset(offset) as any);
+
+    return Response.json({
+      data: results,
+      meta: {
+        total: Number(count),
+        page,
+        limit,
+        totalPages: Math.ceil(Number(count) / limit),
+      },
+    });
+  } catch (err: any) {
+    return Response.json({ error: err.message || "Failed to fetch advocates" }, { status: 500 });
+  }
 }
+

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -5,8 +5,19 @@ const setup = () => {
   if (!process.env.DATABASE_URL) {
     console.error("DATABASE_URL is not set");
     return {
-      select: () => ({
-        from: () => [],
+      select: (..._args: any[]) => ({
+        from: (..._args: any[]) => ({
+          where: (..._args: any[]) => ({
+            limit: (..._args: any[]) => ({
+              offset: (..._args: any[]) => [{ count: 0 }],
+            }),
+          }),
+        }),
+      }),
+      insert: (..._args: any[]) => ({
+        values: (..._args: any[]) => ({
+          returning: (..._args: any[]) => [],
+        }),
       }),
     };
   }

--- a/src/db/seed/advocates.ts
+++ b/src/db/seed/advocates.ts
@@ -37,142 +37,21 @@ const randomSpecialty = () => {
   return [random1, random2];
 };
 
-const advocateData = [
-  {
-    firstName: "John",
-    lastName: "Doe",
-    city: "New York",
-    degree: "MD",
+const advocateData = Array.from({ length: 120 }).map((_, i) => {
+  const firstNames = ["John", "Jane", "Alice", "Michael", "Emily", "Chris", "Jessica", "David", "Laura", "Daniel", "Sarah", "James", "Megan", "Joshua", "Amanda"];
+  const lastNames = ["Doe", "Smith", "Johnson", "Brown", "Davis", "Martinez", "Taylor", "Harris", "Clark", "Lewis", "Lee", "King", "Green", "Walker", "Hall"];
+  const cities = ["New York", "Los Angeles", "Chicago", "Houston", "Phoenix", "Philadelphia", "San Antonio", "San Diego", "Dallas", "San Jose", "Austin", "Jacksonville", "San Francisco", "Columbus", "Fort Worth"];
+  const degrees = ["MD", "PhD", "MSW"];
+
+  return {
+    firstName: firstNames[i % firstNames.length] + i,
+    lastName: lastNames[i % lastNames.length] + i,
+    city: cities[i % cities.length],
+    degree: degrees[i % degrees.length],
     specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 10,
-    phoneNumber: 5551234567,
-  },
-  {
-    firstName: "Jane",
-    lastName: "Smith",
-    city: "Los Angeles",
-    degree: "PhD",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 8,
-    phoneNumber: 5559876543,
-  },
-  {
-    firstName: "Alice",
-    lastName: "Johnson",
-    city: "Chicago",
-    degree: "MSW",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 5,
-    phoneNumber: 5554567890,
-  },
-  {
-    firstName: "Michael",
-    lastName: "Brown",
-    city: "Houston",
-    degree: "MD",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 12,
-    phoneNumber: 5556543210,
-  },
-  {
-    firstName: "Emily",
-    lastName: "Davis",
-    city: "Phoenix",
-    degree: "PhD",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 7,
-    phoneNumber: 5553210987,
-  },
-  {
-    firstName: "Chris",
-    lastName: "Martinez",
-    city: "Philadelphia",
-    degree: "MSW",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 9,
-    phoneNumber: 5557890123,
-  },
-  {
-    firstName: "Jessica",
-    lastName: "Taylor",
-    city: "San Antonio",
-    degree: "MD",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 11,
-    phoneNumber: 5554561234,
-  },
-  {
-    firstName: "David",
-    lastName: "Harris",
-    city: "San Diego",
-    degree: "PhD",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 6,
-    phoneNumber: 5557896543,
-  },
-  {
-    firstName: "Laura",
-    lastName: "Clark",
-    city: "Dallas",
-    degree: "MSW",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 4,
-    phoneNumber: 5550123456,
-  },
-  {
-    firstName: "Daniel",
-    lastName: "Lewis",
-    city: "San Jose",
-    degree: "MD",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 13,
-    phoneNumber: 5553217654,
-  },
-  {
-    firstName: "Sarah",
-    lastName: "Lee",
-    city: "Austin",
-    degree: "PhD",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 10,
-    phoneNumber: 5551238765,
-  },
-  {
-    firstName: "James",
-    lastName: "King",
-    city: "Jacksonville",
-    degree: "MSW",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 5,
-    phoneNumber: 5556540987,
-  },
-  {
-    firstName: "Megan",
-    lastName: "Green",
-    city: "San Francisco",
-    degree: "MD",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 14,
-    phoneNumber: 5559873456,
-  },
-  {
-    firstName: "Joshua",
-    lastName: "Walker",
-    city: "Columbus",
-    degree: "PhD",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 9,
-    phoneNumber: 5556781234,
-  },
-  {
-    firstName: "Amanda",
-    lastName: "Hall",
-    city: "Fort Worth",
-    degree: "MSW",
-    specialties: specialties.slice(...randomSpecialty()),
-    yearsOfExperience: 3,
-    phoneNumber: 5559872345,
-  },
-];
+    yearsOfExperience: (i % 20) + 1,
+    phoneNumber: 5550000000 + i,
+  };
+});
 
 export { advocateData };


### PR DESCRIPTION
Add the ability to search via the API

> [!NOTE]  
> This uses the URL query params to search, which should be only "safe" parameters. Anything more sensitive can be searched via the form.

![solace-api-search-improvements](https://github.com/user-attachments/assets/ff349133-c58f-43fe-8d47-d7f848170ed4)
